### PR TITLE
change access level of pcall to internal. remove test on pcall

### DIFF
--- a/project_u/Assets/Plugins/Lua/_Script/LuaApi.cs
+++ b/project_u/Assets/Plugins/Lua/_Script/LuaApi.cs
@@ -363,9 +363,9 @@ namespace lua
 		}
 
 		[DllImport(LIBNAME, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int lua_pcallk(IntPtr L, int nargs, int nresults, int errfunc, IntPtr ctx, lua_KFunction k);
+		internal static extern int lua_pcallk(IntPtr L, int nargs, int nresults, int errfunc, IntPtr ctx, lua_KFunction k);
 
-		public static int lua_pcall(IntPtr L, int nargs, int nresults, int errfunc)
+		internal static int lua_pcall(IntPtr L, int nargs, int nresults, int errfunc)
 		{
 			return lua_pcallk(L, nargs, nresults, errfunc, IntPtr.Zero, null);
 		}


### PR DESCRIPTION
pcall is coverted by Lua.Call. pcall to a function which calls a managed
methods pushes error object instead of calling lua_error (calls longjmp) to preventing
stack unwinding problem. lua_CFunction never throws. So after called
lua_pcall == LUA_OK, still needs to call Lua.TestError on first ret if
its a error object.